### PR TITLE
Add Windows Compatibility and forward compatibility with Quart

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,12 +1,13 @@
 [project]
 name = "quart-sqlalchemy"
-version = "3.0.4"
+version = "3.0.5"
 description = "SQLAlchemy for humans, with framework adapter for Quart."
 authors = [
     {name = "Joe Black", email = "me@joeblack.nyc"},
 ]
 dependencies = [
-    "quart<0.20.0,>=0.18.3",
+    "quart>=0.18.3 ; python_version >= '3.9'",
+    "quart<0.20.0,>=0.18.3 ; python_version < '3.9'",
     "werkzeug<3.1.0,>=2.2.0",
     "blinker<1.7,>=1.5",
     "SQLAlchemy[asyncio]<2.1.0,>=2.0.0",

--- a/src/quart_sqlalchemy/__init__.py
+++ b/src/quart_sqlalchemy/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "3.0.4"
+__version__ = "3.0.5"
 
 from .bind import AsyncBind
 from .bind import Bind

--- a/src/quart_sqlalchemy/bind.py
+++ b/src/quart_sqlalchemy/bind.py
@@ -258,7 +258,8 @@ def register_engine_connection_cross_process_safety_handlers(
     def close_connections_for_forking():
         engine.dispose(close=False)
 
-    os.register_at_fork(before=close_connections_for_forking)
+    if os.name == 'posix':
+        os.register_at_fork(before=close_connections_for_forking)
 
     def connect(dbapi_connection, connection_record):
         connection_record.info["pid"] = os.getpid()

--- a/tox.ini
+++ b/tox.ini
@@ -4,11 +4,15 @@ skip_missing_interpreters = true
 skip_install = true
 
 [testenv]
+allowlist_externals = 
+    pdm
 commands =
     pdm install --dev
     pytest -v -rsx --tb=short --asyncio-mode=auto --py311-task true --loop-scope session {posargs} tests 
 
 [testenv:q183]
+allowlist_externals = 
+    pdm
 commands =
     pdm install --dev
     pip install aiofiles==23.2.1 blinker==1.5 click==8.1.7 flask==2.2.1 quart==0.18.3 werkzeug==2.2.0 jinja2==3.1.2


### PR DESCRIPTION
I was working on a Quart project when I noticed quart-sqlalchemy lacked compatibility with Quart 0.20.0. I suspect the reason for that is to maintain backwards compatibility with Python 3.8. However, this can be accomplished by modifying the pyproject.toml to install the correct quart package based on python version. 

Also, the tests were failing on windows, the culprit being

```py
os.register_at_fork(before=close_connections_for_forking)
```

Which isn't implemented on Windows, since os.fork doesn't work in Windows. Even if it didn't raise an error, it wouldn't do anything. I am a bit concerned that this simple fix is leaving the underlying issue unaddressed, however all tests pass now. For that reason I feel good about submitting this PR, at very least to start the conversation.

## Summary by Sourcery

Improve Windows compatibility and Quart version support for quart-sqlalchemy

New Features:
- Support for Quart 0.20.0 and Python versions 3.9+

Bug Fixes:
- Resolve Windows compatibility issue with os.register_at_fork by conditionally applying it only on POSIX systems

Enhancements:
- Add version-specific Quart dependency based on Python version to support forward compatibility

Chores:
- Bump package version to 3.0.5